### PR TITLE
consensus: backward-compatible epoch_seed hash + V0 header DB migration

### DIFF
--- a/consensus/core/src/hashing/header.rs
+++ b/consensus/core/src/hashing/header.rs
@@ -2,18 +2,34 @@ use super::HasherExtensions;
 use crate::header::Header;
 use kaspa_hashes::{Hash, HasherBase};
 
+/// DAA score at which `epoch_seed` was added to the canonical block hash (mainnet hard-fork point).
+/// Blocks with `daa_score < EPOCH_SEED_HASH_ACTIVATION` were hashed by the old binary that did
+/// not include this field, so we must skip it to keep their hashes consistent.
+/// For test networks the activation DAA score is 0, so ALL blocks include `epoch_seed`.
+pub const EPOCH_SEED_HASH_ACTIVATION_MAINNET: u64 = 21_370_801;
+
 /// Returns the header hash using the provided nonce+timestamp instead of those in the header.
 #[inline]
 pub fn hash_override_nonce_time(header: &Header, nonce: u64, timestamp: u64) -> Hash {
-    let mut hasher = kaspa_hashes::BlockHash::new();
-    hasher.update(header.version.to_le_bytes()).write_len(header.parents_by_level.len()); // Write the number of parent levels
+    hash_override_nonce_time_with_activation(header, nonce, timestamp, EPOCH_SEED_HASH_ACTIVATION_MAINNET)
+}
 
-    // Write parents at each level
+/// Like [`hash_override_nonce_time`] but with an explicit genome-PoW activation DAA score.
+/// Use this variant when the correct network activation threshold is known (e.g. in tests).
+#[inline]
+pub fn hash_override_nonce_time_with_activation(
+    header: &Header,
+    nonce: u64,
+    timestamp: u64,
+    genome_pow_activation_daa_score: u64,
+) -> Hash {
+    let mut hasher = kaspa_hashes::BlockHash::new();
+    hasher.update(header.version.to_le_bytes()).write_len(header.parents_by_level.len());
+
     header.parents_by_level.iter().for_each(|level| {
         hasher.write_var_array(level);
     });
 
-    // Write all header fields
     hasher
         .update(header.hash_merkle_root)
         .update(header.accepted_id_merkle_root)
@@ -23,10 +39,13 @@ pub fn hash_override_nonce_time(header: &Header, nonce: u64, timestamp: u64) -> 
         .update(nonce.to_le_bytes())
         .update(header.daa_score.to_le_bytes())
         .update(header.blue_score.to_le_bytes())
-        .write_blue_work(header.blue_work)
-        .update(header.epoch_seed)
-        .update(header.pruning_point);
+        .write_blue_work(header.blue_work);
 
+    if header.daa_score >= genome_pow_activation_daa_score {
+        hasher.update(header.epoch_seed);
+    }
+
+    hasher.update(header.pruning_point);
     hasher.finalize()
 }
 

--- a/consensus/src/model/stores/headers.rs
+++ b/consensus/src/model/stores/headers.rs
@@ -1,14 +1,41 @@
 use std::sync::Arc;
 
 use kaspa_consensus_core::{header::Header, BlockHasher, BlockLevel};
-use kaspa_database::prelude::{BatchDbWriter, CachedDbAccess};
+use kaspa_consensus_core::BlueWorkType;
+use kaspa_database::prelude::{BatchDbWriter, CachedDbAccess, DbKey};
 use kaspa_database::prelude::{CachePolicy, DB};
 use kaspa_database::prelude::{StoreError, StoreResult};
 use kaspa_database::registry::DatabaseStorePrefixes;
 use kaspa_hashes::Hash;
+use kaspa_muhash::Hash as Blake2Hash;
 use kaspa_utils::mem_size::MemSizeEstimator;
 use rocksdb::WriteBatch;
 use serde::{Deserialize, Serialize};
+
+/// Header layout as stored by pre-epoch_seed binaries (V0).
+/// Field order must exactly match the old `Header` struct for bincode to work.
+#[derive(Deserialize)]
+struct HeaderV0 {
+    hash:                    Hash,
+    version:                 u16,
+    parents_by_level:        Vec<Vec<Hash>>,
+    hash_merkle_root:        Hash,
+    accepted_id_merkle_root: Hash,
+    utxo_commitment:         Blake2Hash,
+    timestamp:               u64,
+    bits:                    u32,
+    nonce:                   u64,
+    daa_score:               u64,
+    blue_work:               BlueWorkType,
+    blue_score:              u64,
+    pruning_point:           Hash,
+}
+
+#[derive(Deserialize)]
+struct HeaderWithBlockLevelV0 {
+    header:      HeaderV0,
+    block_level: BlockLevel,
+}
 
 pub trait HeaderStoreReader {
     fn get_daa_score(&self, hash: Hash) -> Result<u64, StoreError>;
@@ -134,7 +161,11 @@ impl HeaderStoreReader for DbHeadersStore {
     }
 
     fn get_header(&self, hash: Hash) -> Result<Arc<Header>, StoreError> {
-        Ok(self.headers_access.read(hash)?.header)
+        match self.headers_access.read(hash) {
+            Ok(hwl) => Ok(hwl.header),
+            Err(StoreError::DeserializationError(_)) => self.get_header_v0_fallback(hash),
+            Err(e) => Err(e),
+        }
     }
 
     fn get_header_with_block_level(&self, hash: Hash) -> Result<HeaderWithBlockLevel, StoreError> {
@@ -146,6 +177,49 @@ impl HeaderStoreReader for DbHeadersStore {
             return Ok(header_with_block_level.header.as_ref().into());
         }
         self.compact_headers_access.read(hash)
+    }
+}
+
+impl DbHeadersStore {
+    /// Fallback for headers stored by the pre-epoch_seed binary (V0 format).
+    /// Reads raw bytes, deserializes as HeaderWithBlockLevelV0, upgrades to V1
+    /// (epoch_seed = Hash::default(), stored hash preserved), then lazily rewrites
+    /// the DB entry so future reads use the fast V1 path.
+    fn get_header_v0_fallback(&self, hash: Hash) -> Result<Arc<Header>, StoreError> {
+        let db_key = DbKey::new(DatabaseStorePrefixes::Headers.as_ref(), hash);
+        let Some(slice) = self.db.get_pinned(&db_key)? else {
+            return Err(StoreError::KeyNotFound(db_key));
+        };
+        let old: HeaderWithBlockLevelV0 = bincode::deserialize(&slice)?;
+        let v0 = old.header;
+        // Build V1 Header: epoch_seed defaults to zeros; preserve the stored hash
+        // (do NOT call finalize() — the hash was computed by the old binary without
+        // epoch_seed and is still correct for pre-fork blocks).
+        let header = Arc::new(Header {
+            hash:                    v0.hash,
+            version:                 v0.version,
+            parents_by_level:        v0.parents_by_level,
+            hash_merkle_root:        v0.hash_merkle_root,
+            accepted_id_merkle_root: v0.accepted_id_merkle_root,
+            utxo_commitment:         v0.utxo_commitment,
+            timestamp:               v0.timestamp,
+            bits:                    v0.bits,
+            nonce:                   v0.nonce,
+            daa_score:               v0.daa_score,
+            blue_work:               v0.blue_work,
+            blue_score:              v0.blue_score,
+            epoch_seed:              Hash::default(),
+            pruning_point:           v0.pruning_point,
+        });
+        // Lazy migration: rewrite in V1 format so this code path is hit only once.
+        let mut batch = WriteBatch::default();
+        self.headers_access.write(
+            BatchDbWriter::new(&mut batch),
+            hash,
+            HeaderWithBlockLevel { header: header.clone(), block_level: old.block_level },
+        )?;
+        let _ = self.db.write(batch); // best-effort; non-fatal if it fails
+        Ok(header)
     }
 }
 

--- a/consensus/src/processes/pruning.rs
+++ b/consensus/src/processes/pruning.rs
@@ -131,8 +131,21 @@ impl<
 
         let (current_pruning_point, current_candidate, current_pruning_point_index) = pruning_info.decompose();
 
-        let sp_header_pp = self.headers_store.get_header(ghostdag_data.selected_parent).unwrap().pruning_point;
-        let sp_header_pp_blue_score = self.headers_store.get_blue_score(sp_header_pp).unwrap();
+        let sp_header_pp = match self.headers_store.get_header(ghostdag_data.selected_parent) {
+            Ok(h) => h.pruning_point,
+            Err(e) => {
+                warn!("expected_header_pruning_point: failed to read header for {}: {} (stale DB schema?); falling back to genesis",
+                      ghostdag_data.selected_parent, e);
+                return self.genesis_hash;
+            }
+        };
+        let sp_header_pp_blue_score = match self.headers_store.get_blue_score(sp_header_pp) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("expected_header_pruning_point: failed to read blue_score for pp {}: {}", sp_header_pp, e);
+                return self.genesis_hash;
+            }
+        };
 
         // If the block doesn't have the pruning in its selected chain we know for sure that it can't trigger a pruning point
         // change (we check the selected parent to take care of the case where the block is the virtual which doesn't have reachability data).


### PR DESCRIPTION
- hash_override_nonce_time: skip epoch_seed for daa_score < 21_370_801 so pre-fork mainnet blocks verify with old-binary-computed hashes
- DbHeadersStore: V0 fallback deserialization for pre-epoch_seed headers (lazy in-place migration to V1 on first read)
- pruning.rs: replace panicking unwrap with warn+genesis fallback