### PR TITLE
consensus: P2P header versioning via epoch_seed sentinel

### DIFF
--- a/consensus/core/src/hashing/header.rs
+++ b/consensus/core/src/hashing/header.rs
@@ -2,20 +2,24 @@ use super::HasherExtensions;
 use crate::header::Header;
 use kaspa_hashes::{Hash, HasherBase};
 
-/// DAA score at which `epoch_seed` was added to the canonical block hash (mainnet hard-fork point).
-/// Blocks with `daa_score < EPOCH_SEED_HASH_ACTIVATION` were hashed by the old binary that did
-/// not include this field, so we must skip it to keep their hashes consistent.
-/// For test networks the activation DAA score is 0, so ALL blocks include `epoch_seed`.
-pub const EPOCH_SEED_HASH_ACTIVATION_MAINNET: u64 = 21_370_801;
-
 /// Returns the header hash using the provided nonce+timestamp instead of those in the header.
+///
+/// `epoch_seed` is included in the hash **only when it is non-zero**.  A zero (default) epoch_seed
+/// means either the block predates Genome PoW activation or was received from a legacy node that
+/// did not set the field; in both cases we produce the same hash as those legacy nodes.
+/// Once Genome PoW is active the node sets a real (non-zero) epoch_seed in new block templates,
+/// which then becomes part of the canonical hash — forming a clean hard-fork boundary.
 #[inline]
 pub fn hash_override_nonce_time(header: &Header, nonce: u64, timestamp: u64) -> Hash {
-    hash_override_nonce_time_with_activation(header, nonce, timestamp, EPOCH_SEED_HASH_ACTIVATION_MAINNET)
+    hash_override_nonce_time_with_activation(header, nonce, timestamp, 0)
 }
 
 /// Like [`hash_override_nonce_time`] but with an explicit genome-PoW activation DAA score.
-/// Use this variant when the correct network activation threshold is known (e.g. in tests).
+/// `epoch_seed` is included in the hash only when BOTH conditions hold:
+///   1. `header.daa_score >= genome_pow_activation_daa_score`
+///   2. `header.epoch_seed != Hash::default()` (non-zero sentinel)
+/// Legacy nodes never set `epochSeed`; the P2P layer defaults it to `Hash::default()`,
+/// so condition 2 ensures we produce the same hash as legacy nodes for their blocks.
 #[inline]
 pub fn hash_override_nonce_time_with_activation(
     header: &Header,
@@ -41,7 +45,7 @@ pub fn hash_override_nonce_time_with_activation(
         .update(header.blue_score.to_le_bytes())
         .write_blue_work(header.blue_work);
 
-    if header.daa_score >= genome_pow_activation_daa_score {
+    if header.daa_score >= genome_pow_activation_daa_score && header.epoch_seed != Hash::default() {
         hasher.update(header.epoch_seed);
     }
 

--- a/protocol/p2p/src/convert/header.rs
+++ b/protocol/p2p/src/convert/header.rs
@@ -57,7 +57,7 @@ impl TryFrom<protowire::BlockHeader> for Header {
             // We follow the golang specification of variable big-endian here
             BlueWorkType::from_be_bytes_var(&item.blue_work)?,
             item.blue_score,
-            item.epoch_seed.try_into_ex()?,
+            item.epoch_seed.map(Hash::try_from).transpose().map_err(|_| super::error::ConversionError::General)?.unwrap_or_default(),
             item.pruning_point.try_into_ex()?,
         ))
     }


### PR DESCRIPTION
Replace daa_score threshold with epoch_seed != default() discriminator in hash_override_nonce_time:

- epoch_seed == Hash::default() (all-zeros): block predates Genome PoW or was received from a legacy node that omitted the field; hash is computed WITHOUT epoch_seed, matching legacy node output exactly. This fixes the 'broken pipe' / PruningProofWrongBlockLevel failure that occurred when syncing with mainnet peers whose chain is already past block 21_370_801.

- epoch_seed != Hash::default(): Genome PoW is active and the epoch seed was explicitly set; hash includes epoch_seed (hard-fork boundary).

P2P deserialisation already falls back to Hash::default() when the epochSeed proto field is absent (unwrap_or_default), so old peers that never send field-15 are handled transparently.