### PR TITLE
Fix KHeavyHash GPU mining: unconditional PoW validation + shader over…

### DIFF
--- a/consensus/core/src/hashing/header.rs
+++ b/consensus/core/src/hashing/header.rs
@@ -2,6 +2,9 @@ use super::HasherExtensions;
 use crate::header::Header;
 use kaspa_hashes::{Hash, HasherBase};
 
+/// DAA score at which Genome PoW activates on mainnet.
+pub const EPOCH_SEED_HASH_ACTIVATION_MAINNET: u64 = 21_370_801;
+
 /// Returns the header hash using the provided nonce+timestamp instead of those in the header.
 ///
 /// `epoch_seed` is included in the hash **only when it is non-zero**.  A zero (default) epoch_seed

--- a/consensus/pow/src/matrix.rs
+++ b/consensus/pow/src/matrix.rs
@@ -98,6 +98,18 @@ impl Matrix {
         rank
     }
 
+    /// Export matrix as a flat Vec<u32> (4096 entries, one per element, values 0-15).
+    /// Row-major: index = row * 64 + col.  Used to upload to GPU.
+    pub fn to_flat_u32(&self) -> Vec<u32> {
+        let mut out = Vec::with_capacity(64 * 64);
+        for row in &self.0 {
+            for &v in row {
+                out.push(v as u32);
+            }
+        }
+        out
+    }
+
     pub fn heavy_hash(&self, hash: Hash) -> Hash {
         // SAFETY: An uninitialized MaybrUninit is always safe.
         let mut vec: [MaybeUninit<u8>; 64] = unsafe { MaybeUninit::uninit().assume_init() };

--- a/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
+++ b/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
@@ -105,7 +105,7 @@ impl HeaderProcessor {
         } else {
             let state = kaspa_pow::State::new(header);
             let (passed, pow) = state.check_pow(header.nonce);
-            if !passed && !self.skip_proof_of_work {
+            if !passed {
                 return Err(RuleError::InvalidPoW);
             }
             pow
@@ -136,7 +136,7 @@ impl HeaderProcessor {
             None => self.synthesize_fragment(fragment_idx, &header.epoch_seed),
         };
         let (passed, pow, _fitness) = state.check_pow_with_fragment(header.nonce, &fragment);
-        if passed || self.skip_proof_of_work {
+        if passed {
             Ok(pow)
         } else {
             Err(RuleError::InvalidPoW)

--- a/genome-miner/src/gpu.rs
+++ b/genome-miner/src/gpu.rs
@@ -8,10 +8,10 @@ use kaspa_addresses::Address;
 use kaspa_consensus_core::header::Header;
 use kaspa_core::{info, warn};
 use kaspa_grpc_client::GrpcClient;
-use kaspa_pow::genome_pow::{
+use kaspa_pow::{genome_pow::{
     apply_mutations, fragment_index, genome_fragment_pow_hash, GenomeDatasetLoader,
     SyntheticLoader, GENOME_BASE_SIZE,
-};
+}, matrix::Matrix, State as KHeavyState};
 use kaspa_rpc_core::{api::rpc::RpcApi, model::message::GetBlockTemplateRequest, RpcRawBlock};
 use tokio::time::sleep;
 use wgpu::util::DeviceExt;
@@ -19,10 +19,11 @@ use wgpu::util::DeviceExt;
 // ── GPU pipeline ──────────────────────────────────────────────────────────────
 
 struct GpuContext {
-    device:   wgpu::Device,
-    queue:    wgpu::Queue,
-    pipeline: wgpu::ComputePipeline,
-    bind_layout: wgpu::BindGroupLayout,
+    device:      wgpu::Device,
+    queue:       wgpu::Queue,
+    pipeline:    wgpu::ComputePipeline,   // Genome PoW
+    kh_pipeline: wgpu::ComputePipeline,   // KHeavyHash (pre-activation)
+    bind_layout: wgpu::BindGroupLayout,   // shared: 3×storage bindings
 }
 
 impl GpuContext {
@@ -47,6 +48,12 @@ impl GpuContext {
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label:  Some("genome_pow"),
             source: wgpu::ShaderSource::Wgsl(shader_src.into()),
+        });
+
+        let kh_shader_src = include_str!("kheavyhash3.wgsl");
+        let kh_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label:  Some("kheavyhash"),
+            source: wgpu::ShaderSource::Wgsl(kh_shader_src.into()),
         });
 
         let bind_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -103,7 +110,16 @@ impl GpuContext {
             cache: None,
         });
 
-        Self { device, queue, pipeline, bind_layout }
+        let kh_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label:       Some("kheavyhash_cp"),
+            layout:      Some(&pipeline_layout),
+            module:      &kh_shader,
+            entry_point: "main",
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+        Self { device, queue, pipeline, kh_pipeline, bind_layout }
     }
 }
 
@@ -127,6 +143,111 @@ fn precompute_fragment_hashes(
     }
     info!("Fragment hashes pre-computed.");
     out
+}
+
+// ── KHeavyHash matrix helpers ────────────────────────────────────────────────
+
+/// Generate the KHeavyHash matrix from pre_pow_hash and return as raw bytes
+/// (4096 × u32 LE, row-major, values 0-15).  ~16 KB, uploaded once per template.
+fn build_matrix_bytes(pre_pow_hash: &kaspa_hashes::Hash) -> Vec<u8> {
+    let matrix = Matrix::generate(*pre_pow_hash);
+    let flat = matrix.to_flat_u32();
+    flat.iter().flat_map(|v| v.to_le_bytes()).collect()
+}
+
+/// Build the 88-byte KHeavyParams buffer for the WGSL KHeavyHash shader.
+fn build_kheavy_params(
+    pre_pow_hash: &kaspa_hashes::Hash,
+    timestamp: u64,
+    target: &kaspa_math::Uint256,
+    nonce_base: u64,
+) -> Vec<u8> {
+    let mut buf = vec![0u8; 88];
+    buf[0..32].copy_from_slice(pre_pow_hash.as_ref());
+    buf[32..36].copy_from_slice(&(timestamp as u32).to_le_bytes());
+    buf[36..40].copy_from_slice(&((timestamp >> 32) as u32).to_le_bytes());
+    buf[40..72].copy_from_slice(&target.to_le_bytes());
+    buf[72..76].copy_from_slice(&(nonce_base as u32).to_le_bytes());
+    buf[76..80].copy_from_slice(&((nonce_base >> 32) as u32).to_le_bytes());
+    // buf[80..88] = 0 (pad)
+    buf
+}
+
+/// GPU KHeavyHash dispatch.  matrix_buf holds the pre-uploaded 64×64 matrix.
+/// Returns `Some((nonce, gpu_hash))` on success so the caller can CPU-verify the hash.
+async fn gpu_search_kheavy(
+    ctx: &GpuContext,
+    params_data: &[u8],
+    matrix_buf: &wgpu::Buffer,
+    batch_size: u32,
+) -> Option<(u64, [u32; 8])> {
+    let dev = &ctx.device;
+
+    let params_buf = dev.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label:    Some("kh_params"),
+        contents: params_data,
+        usage:    wgpu::BufferUsages::STORAGE,
+    });
+
+    // 48 bytes: found(4) + nonce_lo(4) + nonce_hi(4) + pad(4) + dbg_hash(32)
+    let output_buf = dev.create_buffer(&wgpu::BufferDescriptor {
+        label:              Some("kh_output"),
+        size:               48,
+        usage:              wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: true,
+    });
+    output_buf.slice(..).get_mapped_range_mut().fill(0);
+    output_buf.unmap();
+
+    let readback_buf = dev.create_buffer(&wgpu::BufferDescriptor {
+        label:              Some("kh_readback"),
+        size:               48,
+        usage:              wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let bind_group = dev.create_bind_group(&wgpu::BindGroupDescriptor {
+        label:  Some("kh_bg"),
+        layout: &ctx.bind_layout,
+        entries: &[
+            wgpu::BindGroupEntry { binding: 0, resource: params_buf.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 1, resource: matrix_buf.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 2, resource: output_buf.as_entire_binding() },
+        ],
+    });
+
+    let mut encoder = dev.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+        pass.set_pipeline(&ctx.kh_pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.dispatch_workgroups((batch_size + 255) / 256, 1, 1);
+    }
+    encoder.copy_buffer_to_buffer(&output_buf, 0, &readback_buf, 0, 48);
+    ctx.queue.submit(std::iter::once(encoder.finish()));
+
+    let slice = readback_buf.slice(..);
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    slice.map_async(wgpu::MapMode::Read, move |r| { let _ = tx.send(r); });
+    dev.poll(wgpu::Maintain::Wait);
+    rx.await.ok()?.ok()?;
+
+    let data     = slice.get_mapped_range();
+    let found    = u32::from_le_bytes(data[0..4].try_into().unwrap());
+    let nonce_lo = u32::from_le_bytes(data[4..8].try_into().unwrap());
+    let nonce_hi = u32::from_le_bytes(data[8..12].try_into().unwrap());
+    let mut gpu_hash = [0u32; 8];
+    for i in 0..8 {
+        gpu_hash[i] = u32::from_le_bytes(data[16 + i*4..16 + i*4 + 4].try_into().unwrap());
+    }
+    drop(data);
+    readback_buf.unmap();
+
+    if found != 0 {
+        Some(((nonce_lo as u64) | ((nonce_hi as u64) << 32), gpu_hash))
+    } else {
+        None
+    }
 }
 
 // ── GPU nonce batch ───────────────────────────────────────────────────────────
@@ -281,8 +402,17 @@ pub async fn cmd_gpu(m: &ArgMatches) {
         usage:    wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
     });
 
+    // KHeavyHash matrix buffer: 4096 × u32 = 16 KB, updated per template
+    let matrix_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label:              Some("kh_matrix"),
+        size:               4096 * 4,
+        usage:              wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
     let mut last_template_id: Option<kaspa_hashes::Hash> = None;
     let mut last_epoch_seed: kaspa_hashes::Hash = epoch_seed_zero;
+    let mut last_pre_pow_hash: Option<kaspa_hashes::Hash> = None;
     let mut nonce_base: u64 = 0;
     let mut total_hashes: u64 = 0;
     let mut report_timer = Instant::now();
@@ -318,8 +448,60 @@ pub async fn cmd_gpu(m: &ArgMatches) {
         }
 
         if header.daa_score < genome_activation {
-            warn!("Genome PoW not yet active (daa={} < activation={}); sleeping.", header.daa_score, genome_activation);
-            sleep(Duration::from_secs(5)).await;
+            // Pre-activation: mine KHeavyHash (PyrinHashv2) on GPU
+            let pre_pow_hash = kaspa_consensus_core::hashing::header::hash_override_nonce_time(&header, 0, 0);
+            let target = kaspa_math::Uint256::from_compact_target_bits(header.bits);
+
+            // Re-upload matrix when template changes (pre_pow_hash → new matrix)
+            if last_pre_pow_hash != Some(pre_pow_hash) {
+                let mat_bytes = build_matrix_bytes(&pre_pow_hash);
+                ctx.queue.write_buffer(&matrix_buf, 0, &mat_bytes);
+                last_pre_pow_hash = Some(pre_pow_hash);
+            }
+
+            let kh_params = build_kheavy_params(&pre_pow_hash, header.timestamp, &target, nonce_base);
+            let solution = gpu_search_kheavy(&ctx, &kh_params, &matrix_buf, batch_size).await;
+            total_hashes += batch_size as u64;
+            nonce_base = nonce_base.wrapping_add(batch_size as u64);
+
+            if let Some((nonce, gpu_hash)) = solution {
+                // CPU cross-check: verify the GPU nonce before submitting
+                let pow_state = KHeavyState::new(&header);
+                let (cpu_valid, cpu_pow) = pow_state.check_pow(nonce);
+                // Convert CPU Uint256 → [u32; 8] LE for comparison
+                let cpu_bytes = cpu_pow.to_le_bytes();
+                let mut cpu_hash = [0u32; 8];
+                for i in 0..8 {
+                    cpu_hash[i] = u32::from_le_bytes(cpu_bytes[i*4..i*4+4].try_into().unwrap());
+                }
+                if gpu_hash != cpu_hash {
+                    warn!(
+                        "GPU KHeavyHash hash mismatch nonce={}: gpu={:08x}{:08x} cpu={:08x}{:08x}",
+                        nonce,
+                        gpu_hash[7], gpu_hash[6],
+                        cpu_hash[7], cpu_hash[6]
+                    );
+                }
+                if !cpu_valid {
+                    warn!("GPU KHeavyHash false-positive nonce={} — skipping invalid block", nonce);
+                    last_template_id = None;
+                    continue;
+                }
+                let solved = build_raw_block_nonce(&rpc_block, nonce);
+                match rpc.submit_block(solved, false).await {
+                    Ok(r)  => info!("Block submitted (KHeavyHash GPU): {:?}", r.report),
+                    Err(e) => warn!("submit_block: {e}"),
+                }
+                last_template_id = None;
+            }
+            if report_timer.elapsed() >= Duration::from_secs(5) {
+                let elapsed = report_timer.elapsed().as_secs_f64();
+                let mhs = total_hashes as f64 / elapsed / 1_000_000.0;
+                info!("GPU [KHeavyHash] [{:.2} MH/s] daa={} (genome activates at {})",
+                    mhs, header.daa_score, genome_activation);
+                total_hashes = 0;
+                report_timer = Instant::now();
+            }
             continue;
         }
 
@@ -345,6 +527,7 @@ pub async fn cmd_gpu(m: &ArgMatches) {
                 Ok(r)  => info!("Block submitted: {:?}", r.report),
                 Err(e) => warn!("submit_block: {e}"),
             }
+            last_template_id = None;
         }
 
         if report_timer.elapsed() >= Duration::from_secs(5) {

--- a/genome-miner/src/kheavyhash.wgsl
+++ b/genome-miner/src/kheavyhash.wgsl
@@ -1,0 +1,202 @@
+// KHeavyHash (PyrinHashv2) GPU compute shader
+// Per-nonce:
+//   1. PowHash  = blake3(pre_pow_hash[32] || timestamp[8] || zeros[32] || nonce[8]) -> 32 B
+//   2. HeavyHash:
+//      a. expand PowHash to 64 nibbles
+//      b. matrix[64x64] * nibbles -> 32 product bytes (nibble fold + XOR)
+//      c. result = blake3(product[32])
+//   3. result ≤ target  -> winner
+
+// ── Blake3 IV / helpers ────────────────────────────────────────────────────────
+const IV0:u32=0x6A09E667u; const IV1:u32=0xBB67AE85u;
+const IV2:u32=0x3C6EF372u; const IV3:u32=0xA54FF53Au;
+const IV4:u32=0x510E527Fu; const IV5:u32=0x9B05688Cu;
+const IV6:u32=0x1F83D9ABu; const IV7:u32=0x5BE0CD19u;
+
+fn rotr(x:u32,n:u32)->u32{return(x>>n)|(x<<(32u-n));}
+
+fn b3g(v:ptr<function,array<u32,16>>,a:u32,b:u32,c:u32,d:u32,x:u32,y:u32){
+    (*v)[a]=(*v)[a]+(*v)[b]+x; (*v)[d]=rotr((*v)[d]^(*v)[a],16u);
+    (*v)[c]=(*v)[c]+(*v)[d];   (*v)[b]=rotr((*v)[b]^(*v)[c],12u);
+    (*v)[a]=(*v)[a]+(*v)[b]+y; (*v)[d]=rotr((*v)[d]^(*v)[a],8u);
+    (*v)[c]=(*v)[c]+(*v)[d];   (*v)[b]=rotr((*v)[b]^(*v)[c],7u);
+}
+
+fn b3_compress(c0:u32,c1:u32,c2:u32,c3:u32,c4:u32,c5:u32,c6:u32,c7:u32,
+               m:ptr<function,array<u32,16>>,clo:u32,chi:u32,bl:u32,fl:u32)->array<u32,8>{
+    var v:array<u32,16>;
+    v[0]=c0;v[1]=c1;v[2]=c2;v[3]=c3;v[4]=c4;v[5]=c5;v[6]=c6;v[7]=c7;
+    v[8]=IV0;v[9]=IV1;v[10]=IV2;v[11]=IV3;v[12]=clo;v[13]=chi;v[14]=bl;v[15]=fl;
+    b3g(&v,0u,4u,8u, 12u,(*m)[0], (*m)[1]); b3g(&v,1u,5u,9u, 13u,(*m)[2], (*m)[3]);
+    b3g(&v,2u,6u,10u,14u,(*m)[4], (*m)[5]); b3g(&v,3u,7u,11u,15u,(*m)[6], (*m)[7]);
+    b3g(&v,0u,5u,10u,15u,(*m)[8], (*m)[9]); b3g(&v,1u,6u,11u,12u,(*m)[10],(*m)[11]);
+    b3g(&v,2u,7u,8u, 13u,(*m)[12],(*m)[13]);b3g(&v,3u,4u,9u, 14u,(*m)[14],(*m)[15]);
+    b3g(&v,0u,4u,8u, 12u,(*m)[2], (*m)[6]); b3g(&v,1u,5u,9u, 13u,(*m)[3], (*m)[10]);
+    b3g(&v,2u,6u,10u,14u,(*m)[7], (*m)[0]); b3g(&v,3u,7u,11u,15u,(*m)[4], (*m)[13]);
+    b3g(&v,0u,5u,10u,15u,(*m)[1], (*m)[11]);b3g(&v,1u,6u,11u,12u,(*m)[12],(*m)[5]);
+    b3g(&v,2u,7u,8u, 13u,(*m)[9], (*m)[14]);b3g(&v,3u,4u,9u, 14u,(*m)[15],(*m)[8]);
+    b3g(&v,0u,4u,8u, 12u,(*m)[3], (*m)[4]); b3g(&v,1u,5u,9u, 13u,(*m)[10],(*m)[12]);
+    b3g(&v,2u,6u,10u,14u,(*m)[13],(*m)[2]); b3g(&v,3u,7u,11u,15u,(*m)[7], (*m)[14]);
+    b3g(&v,0u,5u,10u,15u,(*m)[6], (*m)[5]); b3g(&v,1u,6u,11u,12u,(*m)[9], (*m)[0]);
+    b3g(&v,2u,7u,8u, 13u,(*m)[11],(*m)[15]);b3g(&v,3u,4u,9u, 14u,(*m)[8], (*m)[1]);
+    b3g(&v,0u,4u,8u, 12u,(*m)[10],(*m)[7]); b3g(&v,1u,5u,9u, 13u,(*m)[12],(*m)[9]);
+    b3g(&v,2u,6u,10u,14u,(*m)[14],(*m)[3]); b3g(&v,3u,7u,11u,15u,(*m)[13],(*m)[15]);
+    b3g(&v,0u,5u,10u,15u,(*m)[4], (*m)[0]); b3g(&v,1u,6u,11u,12u,(*m)[11],(*m)[2]);
+    b3g(&v,2u,7u,8u, 13u,(*m)[5], (*m)[8]); b3g(&v,3u,4u,9u, 14u,(*m)[1], (*m)[6]);
+    b3g(&v,0u,4u,8u, 12u,(*m)[12],(*m)[13]);b3g(&v,1u,5u,9u, 13u,(*m)[9], (*m)[11]);
+    b3g(&v,2u,6u,10u,14u,(*m)[15],(*m)[10]);b3g(&v,3u,7u,11u,15u,(*m)[14],(*m)[8]);
+    b3g(&v,0u,5u,10u,15u,(*m)[7], (*m)[2]); b3g(&v,1u,6u,11u,12u,(*m)[5], (*m)[3]);
+    b3g(&v,2u,7u,8u, 13u,(*m)[0], (*m)[1]); b3g(&v,3u,4u,9u, 14u,(*m)[6], (*m)[4]);
+    b3g(&v,0u,4u,8u, 12u,(*m)[9], (*m)[14]);b3g(&v,1u,5u,9u, 13u,(*m)[11],(*m)[5]);
+    b3g(&v,2u,6u,10u,14u,(*m)[8], (*m)[12]);b3g(&v,3u,7u,11u,15u,(*m)[15],(*m)[1]);
+    b3g(&v,0u,5u,10u,15u,(*m)[13],(*m)[3]); b3g(&v,1u,6u,11u,12u,(*m)[0], (*m)[10]);
+    b3g(&v,2u,7u,8u, 13u,(*m)[2], (*m)[6]); b3g(&v,3u,4u,9u, 14u,(*m)[4], (*m)[7]);
+    b3g(&v,0u,4u,8u, 12u,(*m)[11],(*m)[15]);b3g(&v,1u,5u,9u, 13u,(*m)[5], (*m)[0]);
+    b3g(&v,2u,6u,10u,14u,(*m)[1], (*m)[9]); b3g(&v,3u,7u,11u,15u,(*m)[8], (*m)[6]);
+    b3g(&v,0u,5u,10u,15u,(*m)[14],(*m)[10]);b3g(&v,1u,6u,11u,12u,(*m)[2], (*m)[12]);
+    b3g(&v,2u,7u,8u, 13u,(*m)[3], (*m)[4]); b3g(&v,3u,4u,9u, 14u,(*m)[7], (*m)[13]);
+    v[0]^=v[8];v[1]^=v[9];v[2]^=v[10];v[3]^=v[11];
+    v[4]^=v[12];v[5]^=v[13];v[6]^=v[14];v[7]^=v[15];
+    return array<u32,8>(v[0],v[1],v[2],v[3],v[4],v[5],v[6],v[7]);
+}
+
+// ── PowHash: blake3 of 80 bytes in two blocks ─────────────────────────────────
+// Block1 (64 B, CHUNK_START=1): pre_pow_hash[32] || timestamp[8] || zeros[24]
+// Block2 (16 B, CHUNK_END|ROOT=10): zeros[8] || nonce[8]
+fn pow_hash(ph:array<u32,8>,ts_lo:u32,ts_hi:u32,nonce_lo:u32,nonce_hi:u32)->array<u32,8>{
+    var m1:array<u32,16>;
+    m1[0]=ph[0];m1[1]=ph[1];m1[2]=ph[2];m1[3]=ph[3];
+    m1[4]=ph[4];m1[5]=ph[5];m1[6]=ph[6];m1[7]=ph[7];
+    m1[8]=ts_lo;m1[9]=ts_hi;
+    // m1[10..15] = 0 (zeros[24])
+    m1[10]=0u;m1[11]=0u;m1[12]=0u;m1[13]=0u;m1[14]=0u;m1[15]=0u;
+    let cv=b3_compress(IV0,IV1,IV2,IV3,IV4,IV5,IV6,IV7,&m1,0u,0u,64u,1u);
+    var m2:array<u32,16>;
+    // m2[0..1] = zeros[8], m2[2..3] = nonce
+    m2[0]=0u;m2[1]=0u;m2[2]=nonce_lo;m2[3]=nonce_hi;
+    m2[4]=0u;m2[5]=0u;m2[6]=0u;m2[7]=0u;
+    m2[8]=0u;m2[9]=0u;m2[10]=0u;m2[11]=0u;
+    m2[12]=0u;m2[13]=0u;m2[14]=0u;m2[15]=0u;
+    return b3_compress(cv[0],cv[1],cv[2],cv[3],cv[4],cv[5],cv[6],cv[7],&m2,0u,0u,16u,10u);
+}
+
+// ── KHeavyHash final: blake3 of 32 bytes (single block, flags=11) ─────────────
+fn kheavy_final(d:array<u32,8>)->array<u32,8>{
+    var m:array<u32,16>;
+    m[0]=d[0];m[1]=d[1];m[2]=d[2];m[3]=d[3];
+    m[4]=d[4];m[5]=d[5];m[6]=d[6];m[7]=d[7];
+    m[8]=0u;m[9]=0u;m[10]=0u;m[11]=0u;m[12]=0u;m[13]=0u;m[14]=0u;m[15]=0u;
+    return b3_compress(IV0,IV1,IV2,IV3,IV4,IV5,IV6,IV7,&m,0u,0u,32u,11u);
+}
+
+// ── 256-bit LE ≤ comparison ────────────────────────────────────────────────────
+fn le256(a:array<u32,8>,b:array<u32,8>)->bool{
+    if a[7]<b[7]{return true;} if a[7]>b[7]{return false;}
+    if a[6]<b[6]{return true;} if a[6]>b[6]{return false;}
+    if a[5]<b[5]{return true;} if a[5]>b[5]{return false;}
+    if a[4]<b[4]{return true;} if a[4]>b[4]{return false;}
+    if a[3]<b[3]{return true;} if a[3]>b[3]{return false;}
+    if a[2]<b[2]{return true;} if a[2]>b[2]{return false;}
+    if a[1]<b[1]{return true;} if a[1]>b[1]{return false;}
+    if a[0]<b[0]{return true;} if a[0]>b[0]{return false;}
+    return true;
+}
+
+// ── Bindings ───────────────────────────────────────────────────────────────────
+struct KHeavyParams {
+    pre_pow_hash:  array<u32,8>,
+    timestamp_lo:  u32,
+    timestamp_hi:  u32,
+    pow_target:    array<u32,8>,
+    nonce_base_lo: u32,
+    nonce_base_hi: u32,
+    pad0: u32,
+    pad1: u32,
+}
+struct KHeavyOutput {
+    found:    atomic<u32>,
+    nonce_lo: u32,
+    nonce_hi: u32,
+    pad0:     u32,
+    dbg_hash: array<u32,8>,  // GPU final hash of winning nonce (for CPU comparison)
+}
+
+@group(0) @binding(0) var<storage,read>        kparams: KHeavyParams;
+// matrix: 4096 u32s (matrix[row*64+col], each value 0-15)
+@group(0) @binding(1) var<storage,read>        mat:     array<u32>;
+@group(0) @binding(2) var<storage,read_write>  kout:    KHeavyOutput;
+
+// ── Kernel ─────────────────────────────────────────────────────────────────────
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid:vec3<u32>){
+    let delta=gid.x;
+    var nonce_lo=kparams.nonce_base_lo+delta;
+    var nonce_hi=kparams.nonce_base_hi;
+    if nonce_lo<delta{nonce_hi+=1u;}
+
+    // Step 1: PowHash (80-byte blake3)
+    // Copy into var so dynamic indexing is valid (naga forbids indexing let-bound arrays)
+    var h1: array<u32,8>;
+    {let t=pow_hash(kparams.pre_pow_hash,kparams.timestamp_lo,kparams.timestamp_hi,nonce_lo,nonce_hi);
+     h1[0]=t[0];h1[1]=t[1];h1[2]=t[2];h1[3]=t[3];
+     h1[4]=t[4];h1[5]=t[5];h1[6]=t[6];h1[7]=t[7];}
+
+    // Step 2a: expand h1 (32 bytes = 8 u32) into 64 nibbles
+    // h1[word] packs bytes LE: byte0=bits[7:0], byte1=bits[15:8], …
+    var nibbles: array<u32,64>;
+    for(var w:u32=0u;w<8u;w++){
+        let word=h1[w];
+        let b0=word&0xFFu;
+        let b1=(word>>8u)&0xFFu;
+        let b2=(word>>16u)&0xFFu;
+        let b3=(word>>24u)&0xFFu;
+        nibbles[w*8u+0u]=(b0>>4u)&0xFu; nibbles[w*8u+1u]=b0&0xFu;
+        nibbles[w*8u+2u]=(b1>>4u)&0xFu; nibbles[w*8u+3u]=b1&0xFu;
+        nibbles[w*8u+4u]=(b2>>4u)&0xFu; nibbles[w*8u+5u]=b2&0xFu;
+        nibbles[w*8u+6u]=(b3>>4u)&0xFu; nibbles[w*8u+7u]=b3&0xFu;
+    }
+
+    // Step 2b: matrix-vector multiply, fold nibbles, XOR with h1 bytes, pack to 8 u32
+    var prod: array<u32,8>;
+    for(var i:u32=0u;i<8u;i++){
+        var out_word:u32=0u;
+        for(var byte_i:u32=0u;byte_i<4u;byte_i++){
+            let out_idx=i*4u+byte_i;
+            var sum1:u32=0u; var sum2:u32=0u;
+            let row1=out_idx*2u; let row2=out_idx*2u+1u;
+            for(var j:u32=0u;j<64u;j++){
+                sum1+=mat[row1*64u+j]*nibbles[j];
+                sum2+=mat[row2*64u+j]*nibbles[j];
+            }
+            let n1=((sum1&0xFu)^((sum1>>4u)&0xFu)^((sum1>>8u)&0xFu))&0xFu;
+            let n2=((sum2&0xFu)^((sum2>>4u)&0xFu)^((sum2>>8u)&0xFu))&0xFu;
+            var pb=(n1<<4u)|n2;
+            pb^=(h1[i]>>(byte_i*8u))&0xFFu;
+            out_word|=(pb<<(byte_i*8u));
+        }
+        prod[i]=out_word;
+    }
+
+    // Step 2c: final = blake3(product[32])
+    var prod_final: array<u32,8>;
+    {let t=kheavy_final(prod);
+     prod_final[0]=t[0];prod_final[1]=t[1];prod_final[2]=t[2];prod_final[3]=t[3];
+     prod_final[4]=t[4];prod_final[5]=t[5];prod_final[6]=t[6];prod_final[7]=t[7];}
+    let final_hash=prod_final;
+
+    if le256(final_hash,kparams.pow_target){
+        let slot=atomicAdd(&kout.found,1u);
+        if slot==0u{
+            kout.nonce_lo=nonce_lo;
+            kout.nonce_hi=nonce_hi;
+            kout.dbg_hash[0]=final_hash[0];
+            kout.dbg_hash[1]=final_hash[1];
+            kout.dbg_hash[2]=final_hash[2];
+            kout.dbg_hash[3]=final_hash[3];
+            kout.dbg_hash[4]=final_hash[4];
+            kout.dbg_hash[5]=final_hash[5];
+            kout.dbg_hash[6]=final_hash[6];
+            kout.dbg_hash[7]=final_hash[7];
+        }
+    }
+}

--- a/genome-miner/src/kheavyhash2.wgsl
+++ b/genome-miner/src/kheavyhash2.wgsl
@@ -1,0 +1,223 @@
+// KHeavyHash (PyrinHashv2) GPU compute shader — fully-inlined Blake3
+// All G operations use constant indices to avoid dynamic-via-pointer indexing.
+
+const IV0:u32=0x6A09E667u; const IV1:u32=0xBB67AE85u;
+const IV2:u32=0x3C6EF372u; const IV3:u32=0xA54FF53Au;
+const IV4:u32=0x510E527Fu; const IV5:u32=0x9B05688Cu;
+const IV6:u32=0x1F83D9ABu; const IV7:u32=0x5BE0CD19u;
+
+fn rotr(x:u32,n:u32)->u32{return(x>>n)|(x<<(32u-n));}
+
+// Blake3 compress — fully inlined, no helper function, all constant indices.
+fn b3_compress(
+    c0:u32,c1:u32,c2:u32,c3:u32,c4:u32,c5:u32,c6:u32,c7:u32,
+    m0:u32,m1:u32,m2:u32,m3:u32,m4:u32,m5:u32,m6:u32,m7:u32,
+    m8:u32,m9:u32,m10:u32,m11:u32,m12:u32,m13:u32,m14:u32,m15:u32,
+    clo:u32,chi:u32,bl:u32,fl:u32)->array<u32,8>{
+    var v0=c0;var v1=c1;var v2=c2;var v3=c3;
+    var v4=c4;var v5=c5;var v6=c6;var v7=c7;
+    var v8=IV0;var v9=IV1;var v10=IV2;var v11=IV3;
+    var v12=clo;var v13=chi;var v14=bl;var v15=fl;
+
+    // Round 0  sigma=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
+    v0+=v4+m0;  v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m1;  v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m2;  v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m3;  v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m4;  v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m5;  v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m6;  v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m7;  v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m8;  v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m9;  v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m10; v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m11; v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m12; v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m13; v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m14; v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m15; v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    // Round 1  sigma=[2,6,3,10,7,0,4,13,1,11,12,5,9,14,15,8]
+    v0+=v4+m2;  v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m6;  v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m3;  v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m10; v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m7;  v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m0;  v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m4;  v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m13; v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m1;  v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m11; v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m12; v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m5;  v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m9;  v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m14; v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m15; v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m8;  v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    // Round 2  sigma=[3,4,10,12,13,2,7,14,6,5,9,0,11,15,8,1]
+    v0+=v4+m3;  v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m4;  v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m10; v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m12; v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m13; v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m2;  v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m7;  v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m14; v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m6;  v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m5;  v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m9;  v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m0;  v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m11; v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m15; v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m8;  v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m1;  v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    // Round 3  sigma=[10,7,12,9,14,3,13,15,4,0,11,2,5,8,1,6]
+    v0+=v4+m10; v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m7;  v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m12; v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m9;  v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m14; v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m3;  v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m13; v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m15; v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m4;  v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m0;  v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m11; v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m2;  v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m5;  v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m8;  v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m1;  v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m6;  v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    // Round 4  sigma=[12,13,9,11,15,10,14,8,7,2,5,3,0,1,6,4]
+    v0+=v4+m12; v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m13; v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m9;  v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m11; v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m15; v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m10; v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m14; v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m8;  v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m7;  v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m2;  v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m5;  v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m3;  v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m0;  v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m1;  v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m6;  v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m4;  v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    // Round 5  sigma=[9,14,11,5,8,12,15,1,13,3,0,10,2,6,4,7]
+    v0+=v4+m9;  v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m14; v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m11; v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m5;  v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m8;  v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m12; v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m15; v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m1;  v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m13; v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m3;  v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m0;  v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m10; v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m2;  v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m6;  v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m4;  v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m7;  v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    // Round 6  sigma=[11,15,5,0,1,9,8,6,14,10,2,12,3,4,7,13]
+    v0+=v4+m11; v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m15; v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m5;  v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m0;  v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m1;  v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m9;  v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m8;  v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m6;  v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m14; v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m10; v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m2;  v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m12; v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m3;  v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m4;  v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m7;  v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m13; v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    return array<u32,8>(v0^v8,v1^v9,v2^v10,v3^v11,v4^v12,v5^v13,v6^v14,v7^v15);
+}
+
+// PowHash: blake3(pre_pow_hash[32] || timestamp[8] || zeros[32] || nonce[8])
+// Block1 (64 B, CHUNK_START=1): ph[0..7] || ts_lo || ts_hi || zeros[24]
+// Block2 (16 B, CHUNK_END|ROOT=10): zeros[8] || nonce_lo || nonce_hi
+fn pow_hash(ph:array<u32,8>,ts_lo:u32,ts_hi:u32,nonce_lo:u32,nonce_hi:u32)->array<u32,8>{
+    let cv=b3_compress(
+        IV0,IV1,IV2,IV3,IV4,IV5,IV6,IV7,
+        ph[0],ph[1],ph[2],ph[3],ph[4],ph[5],ph[6],ph[7],
+        ts_lo,ts_hi,0u,0u,0u,0u,0u,0u,
+        0u,0u,64u,1u);
+    return b3_compress(
+        cv[0],cv[1],cv[2],cv[3],cv[4],cv[5],cv[6],cv[7],
+        0u,0u,nonce_lo,nonce_hi,0u,0u,0u,0u,
+        0u,0u,0u,0u,0u,0u,0u,0u,
+        0u,0u,16u,10u);
+}
+
+// KHeavyHash final hash: blake3(product[32]) — single block, flags=CHUNK_START|CHUNK_END|ROOT=11
+fn kheavy_final(d:array<u32,8>)->array<u32,8>{
+    return b3_compress(
+        IV0,IV1,IV2,IV3,IV4,IV5,IV6,IV7,
+        d[0],d[1],d[2],d[3],d[4],d[5],d[6],d[7],
+        0u,0u,0u,0u,0u,0u,0u,0u,
+        0u,0u,32u,11u);
+}
+
+// LE 256-bit comparison: return true iff a ≤ b
+fn le256(a:array<u32,8>,b:array<u32,8>)->bool{
+    if a[7]<b[7]{return true;} if a[7]>b[7]{return false;}
+    if a[6]<b[6]{return true;} if a[6]>b[6]{return false;}
+    if a[5]<b[5]{return true;} if a[5]>b[5]{return false;}
+    if a[4]<b[4]{return true;} if a[4]>b[4]{return false;}
+    if a[3]<b[3]{return true;} if a[3]>b[3]{return false;}
+    if a[2]<b[2]{return true;} if a[2]>b[2]{return false;}
+    if a[1]<b[1]{return true;} if a[1]>b[1]{return false;}
+    if a[0]<b[0]{return true;} if a[0]>b[0]{return false;}
+    return true;
+}
+
+struct KHeavyParams {
+    pre_pow_hash:  array<u32,8>,
+    timestamp_lo:  u32,
+    timestamp_hi:  u32,
+    pow_target:    array<u32,8>,
+    nonce_base_lo: u32,
+    nonce_base_hi: u32,
+    pad0: u32,
+    pad1: u32,
+}
+struct KHeavyOutput {
+    found:    atomic<u32>,
+    nonce_lo: u32,
+    nonce_hi: u32,
+    pad0:     u32,
+    dbg_hash: array<u32,8>,
+}
+
+@group(0) @binding(0) var<storage,read>       kparams: KHeavyParams;
+@group(0) @binding(1) var<storage,read>        mat:    array<u32>;
+@group(0) @binding(2) var<storage,read_write>  kout:   KHeavyOutput;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid:vec3<u32>){
+    let delta=gid.x;
+    var nonce_lo=kparams.nonce_base_lo+delta;
+    var nonce_hi=kparams.nonce_base_hi;
+    if nonce_lo<delta{nonce_hi+=1u;}
+
+    // Step 1: PowHash
+    let ph=kparams.pre_pow_hash;
+    var h1:array<u32,8>;
+    {let t=pow_hash(ph,kparams.timestamp_lo,kparams.timestamp_hi,nonce_lo,nonce_hi);
+     h1[0]=t[0];h1[1]=t[1];h1[2]=t[2];h1[3]=t[3];
+     h1[4]=t[4];h1[5]=t[5];h1[6]=t[6];h1[7]=t[7];}
+
+    // Step 2a: expand h1 to 64 nibbles (high nibble first)
+    var nibbles:array<u32,64>;
+    for(var w:u32=0u;w<8u;w++){
+        let word=h1[w];
+        let b0=word&0xFFu;       let b1=(word>>8u)&0xFFu;
+        let b2=(word>>16u)&0xFFu; let b3=(word>>24u)&0xFFu;
+        nibbles[w*8u+0u]=(b0>>4u)&0xFu; nibbles[w*8u+1u]=b0&0xFu;
+        nibbles[w*8u+2u]=(b1>>4u)&0xFu; nibbles[w*8u+3u]=b1&0xFu;
+        nibbles[w*8u+4u]=(b2>>4u)&0xFu; nibbles[w*8u+5u]=b2&0xFu;
+        nibbles[w*8u+6u]=(b3>>4u)&0xFu; nibbles[w*8u+7u]=b3&0xFu;
+    }
+
+    // Step 2b: matrix-vector multiply + fold + XOR
+    var prod:array<u32,8>;
+    for(var i:u32=0u;i<8u;i++){
+        var out_word:u32=0u;
+        for(var byte_i:u32=0u;byte_i<4u;byte_i++){
+            let out_idx=i*4u+byte_i;
+            var sum1:u32=0u; var sum2:u32=0u;
+            let row1=out_idx*2u; let row2=out_idx*2u+1u;
+            for(var j:u32=0u;j<64u;j++){
+                sum1+=mat[row1*64u+j]*nibbles[j];
+                sum2+=mat[row2*64u+j]*nibbles[j];
+            }
+            let n1=((sum1&0xFu)^((sum1>>4u)&0xFu)^((sum1>>8u)&0xFu))&0xFu;
+            let n2=((sum2&0xFu)^((sum2>>4u)&0xFu)^((sum2>>8u)&0xFu))&0xFu;
+            var pb=(n1<<4u)|n2;
+            pb^=(h1[i]>>(byte_i*8u))&0xFFu;
+            out_word|=(pb<<(byte_i*8u));
+        }
+        prod[i]=out_word;
+    }
+
+    // Step 2c: final = blake3(product[32])
+    var final_hash:array<u32,8>;
+    {let t=kheavy_final(prod);
+     final_hash[0]=t[0];final_hash[1]=t[1];final_hash[2]=t[2];final_hash[3]=t[3];
+     final_hash[4]=t[4];final_hash[5]=t[5];final_hash[6]=t[6];final_hash[7]=t[7];}
+
+    if le256(final_hash,kparams.pow_target){
+        let slot=atomicAdd(&kout.found,1u);
+        if slot==0u{
+            kout.nonce_lo=nonce_lo;
+            kout.nonce_hi=nonce_hi;
+            kout.dbg_hash[0]=final_hash[0];
+            kout.dbg_hash[1]=final_hash[1];
+            kout.dbg_hash[2]=final_hash[2];
+            kout.dbg_hash[3]=final_hash[3];
+            kout.dbg_hash[4]=final_hash[4];
+            kout.dbg_hash[5]=final_hash[5];
+            kout.dbg_hash[6]=final_hash[6];
+            kout.dbg_hash[7]=final_hash[7];
+        }
+    }
+}

--- a/genome-miner/src/kheavyhash3.wgsl
+++ b/genome-miner/src/kheavyhash3.wgsl
@@ -1,0 +1,238 @@
+// KHeavyHash (PyrinHashv2) — Blake3 via array-by-value params (6 args, not 28).
+// Passing 28 individual u32s to b3_compress exceeds Metal MSL register limits.
+
+const IV0:u32=0x6A09E667u; const IV1:u32=0xBB67AE85u;
+const IV2:u32=0x3C6EF372u; const IV3:u32=0xA54FF53Au;
+const IV4:u32=0x510E527Fu; const IV5:u32=0x9B05688Cu;
+const IV6:u32=0x1F83D9ABu; const IV7:u32=0x5BE0CD19u;
+
+fn rotr(x:u32,n:u32)->u32{return(x>>n)|(x<<(32u-n));}
+
+// Blake3 compress.  cv and m passed by VALUE (WGSL copies them).
+// 6 parameters instead of 28 individual u32s — avoids Metal MSL spill issues.
+fn b3_compress(cv:array<u32,8>, m:array<u32,16>, clo:u32, chi:u32, bl:u32, fl:u32)->array<u32,8>{
+    var v0=cv[0]; var v1=cv[1]; var v2=cv[2]; var v3=cv[3];
+    var v4=cv[4]; var v5=cv[5]; var v6=cv[6]; var v7=cv[7];
+    var v8=IV0; var v9=IV1; var v10=IV2; var v11=IV3;
+    var v12=clo; var v13=chi; var v14=bl; var v15=fl;
+    // Unpack message words to scalar lets — all constant-indexed reads
+    let m0=m[0]; let m1=m[1]; let m2=m[2];  let m3=m[3];
+    let m4=m[4]; let m5=m[5]; let m6=m[6];  let m7=m[7];
+    let m8=m[8]; let m9=m[9]; let m10=m[10]; let m11=m[11];
+    let m12=m[12]; let m13=m[13]; let m14=m[14]; let m15=m[15];
+
+    // Round 0  sigma=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
+    v0+=v4+m0;  v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m1;  v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m2;  v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m3;  v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m4;  v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m5;  v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m6;  v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m7;  v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m8;  v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m9;  v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m10; v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m11; v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m12; v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m13; v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m14; v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m15; v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    // Round 1  sigma=[2,6,3,10,7,0,4,13,1,11,12,5,9,14,15,8]
+    v0+=v4+m2;  v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m6;  v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m3;  v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m10; v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m7;  v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m0;  v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m4;  v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m13; v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m1;  v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m11; v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m12; v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m5;  v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m9;  v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m14; v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m15; v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m8;  v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    // Round 2  sigma=[3,4,10,12,13,2,7,14,6,5,9,0,11,15,8,1]
+    v0+=v4+m3;  v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m4;  v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m10; v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m12; v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m13; v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m2;  v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m7;  v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m14; v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m6;  v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m5;  v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m9;  v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m0;  v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m11; v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m15; v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m8;  v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m1;  v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    // Round 3  sigma=[10,7,12,9,14,3,13,15,4,0,11,2,5,8,1,6]
+    v0+=v4+m10; v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m7;  v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m12; v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m9;  v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m14; v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m3;  v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m13; v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m15; v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m4;  v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m0;  v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m11; v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m2;  v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m5;  v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m8;  v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m1;  v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m6;  v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    // Round 4  sigma=[12,13,9,11,15,10,14,8,7,2,5,3,0,1,6,4]
+    v0+=v4+m12; v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m13; v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m9;  v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m11; v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m15; v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m10; v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m14; v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m8;  v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m7;  v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m2;  v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m5;  v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m3;  v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m0;  v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m1;  v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m6;  v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m4;  v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    // Round 5  sigma=[9,14,11,5,8,12,15,1,13,3,0,10,2,6,4,7]
+    v0+=v4+m9;  v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m14; v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m11; v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m5;  v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m8;  v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m12; v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m15; v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m1;  v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m13; v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m3;  v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m0;  v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m10; v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m2;  v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m6;  v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m4;  v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m7;  v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    // Round 6  sigma=[11,15,5,0,1,9,8,6,14,10,2,12,3,4,7,13]
+    v0+=v4+m11; v12=rotr(v12^v0,16u); v8+=v12;  v4=rotr(v4^v8,12u);  v0+=v4+m15; v12=rotr(v12^v0,8u);  v8+=v12;  v4=rotr(v4^v8,7u);
+    v1+=v5+m5;  v13=rotr(v13^v1,16u); v9+=v13;  v5=rotr(v5^v9,12u);  v1+=v5+m0;  v13=rotr(v13^v1,8u);  v9+=v13;  v5=rotr(v5^v9,7u);
+    v2+=v6+m1;  v14=rotr(v14^v2,16u); v10+=v14; v6=rotr(v6^v10,12u); v2+=v6+m9;  v14=rotr(v14^v2,8u);  v10+=v14; v6=rotr(v6^v10,7u);
+    v3+=v7+m8;  v15=rotr(v15^v3,16u); v11+=v15; v7=rotr(v7^v11,12u); v3+=v7+m6;  v15=rotr(v15^v3,8u);  v11+=v15; v7=rotr(v7^v11,7u);
+    v0+=v5+m14; v15=rotr(v15^v0,16u); v10+=v15; v5=rotr(v5^v10,12u); v0+=v5+m10; v15=rotr(v15^v0,8u);  v10+=v15; v5=rotr(v5^v10,7u);
+    v1+=v6+m2;  v12=rotr(v12^v1,16u); v11+=v12; v6=rotr(v6^v11,12u); v1+=v6+m12; v12=rotr(v12^v1,8u);  v11+=v12; v6=rotr(v6^v11,7u);
+    v2+=v7+m3;  v13=rotr(v13^v2,16u); v8+=v13;  v7=rotr(v7^v8,12u);  v2+=v7+m4;  v13=rotr(v13^v2,8u);  v8+=v13;  v7=rotr(v7^v8,7u);
+    v3+=v4+m7;  v14=rotr(v14^v3,16u); v9+=v14;  v4=rotr(v4^v9,12u);  v3+=v4+m13; v14=rotr(v14^v3,8u);  v9+=v14;  v4=rotr(v4^v9,7u);
+
+    var out:array<u32,8>;
+    out[0]=v0^v8; out[1]=v1^v9;  out[2]=v2^v10; out[3]=v3^v11;
+    out[4]=v4^v12; out[5]=v5^v13; out[6]=v6^v14; out[7]=v7^v15;
+    return out;
+}
+
+// Blake3 IV constant array (used to construct cv for first compress call)
+fn b3_iv()->array<u32,8>{
+    var iv:array<u32,8>;
+    iv[0]=IV0; iv[1]=IV1; iv[2]=IV2; iv[3]=IV3;
+    iv[4]=IV4; iv[5]=IV5; iv[6]=IV6; iv[7]=IV7;
+    return iv;
+}
+
+// PowHash: blake3(pre_pow_hash[32] || timestamp[8] || zeros[32] || nonce[8])  80 bytes, 2 blocks
+// Block1 (64 B, CHUNK_START=1):  ph[0..7] || ts_lo || ts_hi || zeros[6 words]
+// Block2 (16 B, CHUNK_END|ROOT=10): zeros[2 words] || nonce_lo || nonce_hi
+fn pow_hash(ph:array<u32,8>, ts_lo:u32, ts_hi:u32, nonce_lo:u32, nonce_hi:u32)->array<u32,8>{
+    var m1:array<u32,16>;
+    m1[0]=ph[0]; m1[1]=ph[1]; m1[2]=ph[2]; m1[3]=ph[3];
+    m1[4]=ph[4]; m1[5]=ph[5]; m1[6]=ph[6]; m1[7]=ph[7];
+    m1[8]=ts_lo; m1[9]=ts_hi;
+    m1[10]=0u; m1[11]=0u; m1[12]=0u; m1[13]=0u; m1[14]=0u; m1[15]=0u;
+    let cv=b3_compress(b3_iv(), m1, 0u, 0u, 64u, 1u);
+
+    var m2:array<u32,16>;
+    m2[0]=0u; m2[1]=0u; m2[2]=nonce_lo; m2[3]=nonce_hi;
+    m2[4]=0u; m2[5]=0u; m2[6]=0u; m2[7]=0u;
+    m2[8]=0u; m2[9]=0u; m2[10]=0u; m2[11]=0u; m2[12]=0u; m2[13]=0u; m2[14]=0u; m2[15]=0u;
+    return b3_compress(cv, m2, 0u, 0u, 16u, 10u);
+}
+
+// KHeavyHash final hash: blake3(product[32]) — single block, flags=CHUNK_START|CHUNK_END|ROOT=11
+fn kheavy_final(d:array<u32,8>)->array<u32,8>{
+    var m:array<u32,16>;
+    m[0]=d[0]; m[1]=d[1]; m[2]=d[2]; m[3]=d[3];
+    m[4]=d[4]; m[5]=d[5]; m[6]=d[6]; m[7]=d[7];
+    m[8]=0u; m[9]=0u; m[10]=0u; m[11]=0u; m[12]=0u; m[13]=0u; m[14]=0u; m[15]=0u;
+    return b3_compress(b3_iv(), m, 0u, 0u, 32u, 11u);
+}
+
+// LE 256-bit comparison: return true iff a <= b
+fn le256(a:array<u32,8>, b:array<u32,8>)->bool{
+    if a[7]<b[7]{return true;} if a[7]>b[7]{return false;}
+    if a[6]<b[6]{return true;} if a[6]>b[6]{return false;}
+    if a[5]<b[5]{return true;} if a[5]>b[5]{return false;}
+    if a[4]<b[4]{return true;} if a[4]>b[4]{return false;}
+    if a[3]<b[3]{return true;} if a[3]>b[3]{return false;}
+    if a[2]<b[2]{return true;} if a[2]>b[2]{return false;}
+    if a[1]<b[1]{return true;} if a[1]>b[1]{return false;}
+    if a[0]<b[0]{return true;} if a[0]>b[0]{return false;}
+    return true;
+}
+
+struct KHeavyParams {
+    pre_pow_hash:  array<u32,8>,
+    timestamp_lo:  u32,
+    timestamp_hi:  u32,
+    pow_target:    array<u32,8>,
+    nonce_base_lo: u32,
+    nonce_base_hi: u32,
+    pad0: u32,
+    pad1: u32,
+}
+struct KHeavyOutput {
+    found:    atomic<u32>,
+    nonce_lo: u32,
+    nonce_hi: u32,
+    pad0:     u32,
+    dbg_hash: array<u32,8>,
+}
+
+@group(0) @binding(0) var<storage,read>       kparams: KHeavyParams;
+@group(0) @binding(1) var<storage,read>        mat:    array<u32>;
+@group(0) @binding(2) var<storage,read_write>  kout:   KHeavyOutput;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid:vec3<u32>){
+    let delta=gid.x;
+    var nonce_lo=kparams.nonce_base_lo+delta;
+    var nonce_hi=kparams.nonce_base_hi;
+    if nonce_lo<delta{nonce_hi+=1u;}
+
+    // Step 1: PowHash — blake3(pre_pow_hash || timestamp || zeros[32] || nonce)
+    let ph=kparams.pre_pow_hash;
+    var h1:array<u32,8>;
+    {let t=pow_hash(ph,kparams.timestamp_lo,kparams.timestamp_hi,nonce_lo,nonce_hi);
+     h1[0]=t[0];h1[1]=t[1];h1[2]=t[2];h1[3]=t[3];
+     h1[4]=t[4];h1[5]=t[5];h1[6]=t[6];h1[7]=t[7];}
+
+    // Step 2a: expand h1 to 64 nibbles (high nibble first per byte)
+    var nibbles:array<u32,64>;
+    for(var w:u32=0u;w<8u;w++){
+        let word=h1[w];
+        let b0=word&0xFFu;        let b1=(word>>8u)&0xFFu;
+        let b2=(word>>16u)&0xFFu; let b3=(word>>24u)&0xFFu;
+        nibbles[w*8u+0u]=(b0>>4u)&0xFu; nibbles[w*8u+1u]=b0&0xFu;
+        nibbles[w*8u+2u]=(b1>>4u)&0xFu; nibbles[w*8u+3u]=b1&0xFu;
+        nibbles[w*8u+4u]=(b2>>4u)&0xFu; nibbles[w*8u+5u]=b2&0xFu;
+        nibbles[w*8u+6u]=(b3>>4u)&0xFu; nibbles[w*8u+7u]=b3&0xFu;
+    }
+
+    // Step 2b: matrix-vector multiply + nibble-fold + XOR with h1
+    var prod:array<u32,8>;
+    for(var i:u32=0u;i<8u;i++){
+        var out_word:u32=0u;
+        for(var byte_i:u32=0u;byte_i<4u;byte_i++){
+            let out_idx=i*4u+byte_i;
+            var sum1:u32=0u; var sum2:u32=0u;
+            let row1=out_idx*2u; let row2=out_idx*2u+1u;
+            for(var j:u32=0u;j<64u;j++){
+                sum1+=mat[row1*64u+j]*nibbles[j];
+                sum2+=mat[row2*64u+j]*nibbles[j];
+            }
+            let n1=((sum1&0xFu)^((sum1>>4u)&0xFu)^((sum1>>8u)&0xFu))&0xFu;
+            let n2=((sum2&0xFu)^((sum2>>4u)&0xFu)^((sum2>>8u)&0xFu))&0xFu;
+            var pb=(n1<<4u)|n2;
+            pb^=(h1[i]>>(byte_i*8u))&0xFFu;
+            out_word|=(pb<<(byte_i*8u));
+        }
+        prod[i]=out_word;
+    }
+
+    // Step 2c: final = blake3(product[32])
+    var final_hash:array<u32,8>;
+    {let t=kheavy_final(prod);
+     final_hash[0]=t[0];final_hash[1]=t[1];final_hash[2]=t[2];final_hash[3]=t[3];
+     final_hash[4]=t[4];final_hash[5]=t[5];final_hash[6]=t[6];final_hash[7]=t[7];}
+
+    if le256(final_hash,kparams.pow_target){
+        let slot=atomicAdd(&kout.found,1u);
+        if slot==0u{
+            kout.nonce_lo=nonce_lo;
+            kout.nonce_hi=nonce_hi;
+            kout.dbg_hash[0]=final_hash[0];
+            kout.dbg_hash[1]=final_hash[1];
+            kout.dbg_hash[2]=final_hash[2];
+            kout.dbg_hash[3]=final_hash[3];
+            kout.dbg_hash[4]=final_hash[4];
+            kout.dbg_hash[5]=final_hash[5];
+            kout.dbg_hash[6]=final_hash[6];
+            kout.dbg_hash[7]=final_hash[7];
+        }
+    }
+}


### PR DESCRIPTION
…haul

- pre_ghostdag_validation: remove skip_proof_of_work bypass so node always enforces PoW on both KHeavyHash and GenomePoW paths
- kheavyhash3.wgsl: restructure b3_compress from 28 individual u32 params to array<u32,8>/array<u32,16> by-value (6 params total), fixing Metal/naga MSL register-spill that caused every GPU hash to be wrong; also use var-array return instead of array constructor
- kheavyhash2.wgsl: prior attempt (inlined G ops, 28 params) kept for reference
- gpu.rs: switch shader include to kheavyhash3.wgsl; output buffer 48 B (adds dbg_hash[8] for GPU-vs-CPU comparison); cpu cross-check filters false-positive nonces before block submission