### PR TITLE
fix: IBD InvalidPoW — KHeavyHash pre-pow hash must never include epoc…

### DIFF
--- a/consensus/pow/src/lib.rs
+++ b/consensus/pow/src/lib.rs
@@ -28,12 +28,14 @@ impl State {
     #[inline]
     pub fn new(header: &Header) -> Self {
         let target = Uint256::from_compact_target_bits(header.bits);
-        // Zero out the time and nonce.
-        let pre_pow_hash = hashing::header::hash_override_nonce_time(header, 0, 0);
+        // KHeavyHash never includes epoch_seed in the pre-pow hash.
+        // Using u64::MAX as the activation ensures the condition
+        // `daa_score >= activation` is always false, matching the original
+        // Kaspa hash computation for all existing mainnet blocks.
+        let pre_pow_hash = hashing::header::hash_override_nonce_time_with_activation(header, 0, 0, u64::MAX);
         // PRE_POW_HASH || TIME || 32 zero byte padding || NONCE
         let hasher = PowHash::new(pre_pow_hash, header.timestamp);
         let matrix = Matrix::generate(pre_pow_hash);
-
         Self { matrix, target, hasher }
     }
 

--- a/genome-miner/src/gpu.rs
+++ b/genome-miner/src/gpu.rs
@@ -448,8 +448,9 @@ pub async fn cmd_gpu(m: &ArgMatches) {
         }
 
         if header.daa_score < genome_activation {
-            // Pre-activation: mine KHeavyHash (PyrinHashv2) on GPU
-            let pre_pow_hash = kaspa_consensus_core::hashing::header::hash_override_nonce_time(&header, 0, 0);
+            // Pre-activation: mine KHeavyHash (PyrinHashv2) on GPU.
+            // KHeavyHash never includes epoch_seed in the pre-pow hash (u64::MAX activation).
+            let pre_pow_hash = kaspa_consensus_core::hashing::header::hash_override_nonce_time_with_activation(&header, 0, 0, u64::MAX);
             let target = kaspa_math::Uint256::from_compact_target_bits(header.bits);
 
             // Re-upload matrix when template changes (pre_pow_hash → new matrix)

--- a/genome-miner/src/main.rs
+++ b/genome-miner/src/main.rs
@@ -89,7 +89,6 @@ struct MineConfig {
 
 struct MinerState {
     cfg: MineConfig,
-    loader: Arc<dyn GenomeDatasetLoader>,
     template_generation: AtomicU64,
     template_id: std::sync::Mutex<Option<kaspa_hashes::Hash>>,
     found: AtomicBool,
@@ -97,10 +96,7 @@ struct MinerState {
 
 impl MinerState {
     fn new(cfg: MineConfig) -> Self {
-        let epoch_seed = kaspa_hashes::Hash::from_bytes([0u8; 32]);
-        let inner = SyntheticLoader::new(cfg.genome_fragment_size_bytes, epoch_seed);
-        let loader: Arc<dyn GenomeDatasetLoader> = Arc::new(CachedLoader::new(inner, 256));
-        Self { cfg, loader, template_generation: AtomicU64::new(0), template_id: std::sync::Mutex::new(None), found: AtomicBool::new(false) }
+        Self { cfg, template_generation: AtomicU64::new(0), template_id: std::sync::Mutex::new(None), found: AtomicBool::new(false) }
     }
 }
 
@@ -185,13 +181,18 @@ async fn cmd_mine(m: &ArgMatches) {
         info!("New template daa={} bits={:#010x} genome={}", header.daa_score, header.bits, genome_active);
 
         let batch = state.cfg.nonce_batch;
+        let frag_size = state.cfg.genome_fragment_size_bytes;
+        // Build a per-template loader keyed on the template's epoch_seed so that
+        // synthesized fragment content matches what the validator computes.
+        let template_loader: Arc<dyn GenomeDatasetLoader> = Arc::new(
+            CachedLoader::new(SyntheticLoader::new(frag_size, header.epoch_seed), 256)
+        );
         let mut nonce_base: u64 = 0;
         let solution: Option<u64> = 'search: loop {
             if state.template_generation.load(Ordering::Relaxed) != gen { break 'search None; }
             let range_start = nonce_base;
             nonce_base = nonce_base.saturating_add(batch * state.cfg.threads as u64);
-            let frag_size = state.cfg.genome_fragment_size_bytes;
-            let loader_ref = state.loader.as_ref();
+            let loader_ref = template_loader.as_ref();
             let winning = pool.install(|| {
                 (0..state.cfg.threads as u64).into_par_iter().find_map_first(|tid| {
                     let start = range_start + tid * batch;


### PR DESCRIPTION
…h_seed

Root cause: kaspa_pow::State::new called hash_override_nonce_time with activation=0, making daa_score>=0 always true and including any non-zero epoch_seed in the KHeavyHash pre-pow hash.  All mainnet blocks at DAA>=200 have a non-zero epoch_seed (set by calc_epoch_seed at epoch boundaries every 200 blocks), so their stored PoW hash diverged from what the validator now computed — causing every IBD attempt to fail with InvalidPoW.

Fixes:
- consensus/pow/src/lib.rs: State::new now uses u64::MAX as the activation, so the epoch_seed condition is never satisfied for KHeavyHash blocks, restoring the original Kaspa hash semantics for all pre-genome-PoW blocks.
- genome-miner/src/gpu.rs: GPU miner KHeavyHash path uses the same u64::MAX activation so mined blocks are consistent with the fixed validator.
- genome-miner/src/main.rs: CPU miner builds a per-template CachedLoader keyed on header.epoch_seed so synthesised genome fragments always match what the validator computes (was hardcoded to zero epoch_seed).