### PR TITLE
fix: revert KHeavyHash pre-pow hash to activation=0 (include epoch_seed)

### DIFF
--- a/consensus/pow/src/lib.rs
+++ b/consensus/pow/src/lib.rs
@@ -28,11 +28,9 @@ impl State {
     #[inline]
     pub fn new(header: &Header) -> Self {
         let target = Uint256::from_compact_target_bits(header.bits);
-        // KHeavyHash never includes epoch_seed in the pre-pow hash.
-        // Using u64::MAX as the activation ensures the condition
-        // `daa_score >= activation` is always false, matching the original
-        // Kaspa hash computation for all existing mainnet blocks.
-        let pre_pow_hash = hashing::header::hash_override_nonce_time_with_activation(header, 0, 0, u64::MAX);
+        // epoch_seed is included in the pre-pow hash when non-zero (activation=0).
+        // Xenomorph mainnet blocks were mined with this hash semantics.
+        let pre_pow_hash = hashing::header::hash_override_nonce_time(header, 0, 0);
         // PRE_POW_HASH || TIME || 32 zero byte padding || NONCE
         let hasher = PowHash::new(pre_pow_hash, header.timestamp);
         let matrix = Matrix::generate(pre_pow_hash);

--- a/genome-miner/src/gpu.rs
+++ b/genome-miner/src/gpu.rs
@@ -449,8 +449,8 @@ pub async fn cmd_gpu(m: &ArgMatches) {
 
         if header.daa_score < genome_activation {
             // Pre-activation: mine KHeavyHash (PyrinHashv2) on GPU.
-            // KHeavyHash never includes epoch_seed in the pre-pow hash (u64::MAX activation).
-            let pre_pow_hash = kaspa_consensus_core::hashing::header::hash_override_nonce_time_with_activation(&header, 0, 0, u64::MAX);
+            // epoch_seed is included when non-zero (activation=0), matching mainnet block semantics.
+            let pre_pow_hash = kaspa_consensus_core::hashing::header::hash_override_nonce_time(&header, 0, 0);
             let target = kaspa_math::Uint256::from_compact_target_bits(header.bits);
 
             // Re-upload matrix when template changes (pre_pow_hash → new matrix)


### PR DESCRIPTION
Diagnostic WARN logs proved that DAA ~21.27M blocks have non-zero epoch_seed and fail WITHOUT epoch_seed in the hash.  The blocks were mined WITH epoch_seed (activation=0 semantics), so the validator must also include it.

Reverts the u64::MAX activation introduced in 2d98208 for both:
- consensus/pow/src/lib.rs: State::new uses hash_override_nonce_time (activation=0)
- genome-miner/src/gpu.rs: KHeavyHash GPU path uses same function