### PR TITLE
fix: remove --enable-unsynced-mining, use !is_ibd_running() for idle …

### DIFF
--- a/consensus/core/src/config/mod.rs
+++ b/consensus/core/src/config/mod.rs
@@ -45,10 +45,6 @@ pub struct Config {
     /// Enable RPC commands which affect the state of the node
     pub unsafe_rpc: bool,
 
-    /// Allow the node to accept blocks from RPC while not synced
-    /// (required when initiating a new network from genesis)
-    pub enable_unsynced_mining: bool,
-
     /// Allow mainnet mining. Until a stable Beta version we keep this option off by default
     pub enable_mainnet_mining: bool,
 
@@ -84,7 +80,6 @@ impl Config {
             enable_sanity_checks: true,
             utxoindex: true,
             unsafe_rpc: false,
-            enable_unsynced_mining: false,
             enable_mainnet_mining: true,
             user_agent_comments: Default::default(),
             externalip: None,

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -296,9 +296,13 @@ impl RpcApi for RpcCoreService {
         let session = self.consensus_manager.consensus().unguarded_session();
 
         // TODO: consider adding an error field to SubmitBlockReport to document both the report and error fields
-        let is_synced: bool = self.has_sufficient_peer_connectivity() && session.async_is_nearly_synced().await;
+        // A node is considered ready to mine when it is nearly synced OR when IBD is not running
+        // (meaning no peer has a longer chain — the node is already at the network tip, even if
+        // the chain has been idle for longer than the DAA window).
+        let is_synced: bool = self.has_sufficient_peer_connectivity()
+            && (session.async_is_nearly_synced().await || !self.flow_context.is_ibd_running());
 
-        if !self.config.enable_unsynced_mining && !is_synced {
+        if !is_synced {
             // error = "Block not submitted - node is not synced"
             return Ok(SubmitBlockResponse { report: SubmitBlockReport::Reject(SubmitBlockRejectReason::IsInIBD) });
         }
@@ -378,8 +382,8 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
             return Err(RpcError::CoinbasePayloadLengthAboveMax(self.config.max_coinbase_payload_len));
         }
 
-        let is_nearly_synced =
-            self.config.is_nearly_synced(block_template.selected_parent_timestamp, block_template.selected_parent_daa_score);
+        let is_nearly_synced = self.config.is_nearly_synced(block_template.selected_parent_timestamp, block_template.selected_parent_daa_score)
+            || !self.flow_context.is_ibd_running();
         Ok(GetBlockTemplateResponse {
             block: block_template.block.into(),
             is_synced: self.has_sufficient_peer_connectivity() && is_nearly_synced,

--- a/testing/integration/src/common/args.rs
+++ b/testing/integration/src/common/args.rs
@@ -13,7 +13,6 @@ impl ArgsBuilder {
         let args = Args {
             simnet: true,
             disable_upnp: true, // UPnP registration might take some time and is not needed for this test
-            enable_unsynced_mining: true,
             num_prealloc_utxos: Some(num_prealloc_utxos),
             prealloc_amount: prealloc_amount * kaspa_consensus_core::constants::SOMPI_PER_KASPA,
             block_template_cache_lifetime: Some(0),
@@ -30,7 +29,6 @@ impl ArgsBuilder {
         let args = Args {
             simnet: true,
             disable_upnp: true, // UPnP registration might take some time and is not needed for this test
-            enable_unsynced_mining: true,
             block_template_cache_lifetime: Some(0),
             rpc_max_clients: 2500,
             unsafe_rpc: true,

--- a/testing/integration/src/daemon_integration_tests.rs
+++ b/testing/integration/src/daemon_integration_tests.rs
@@ -51,7 +51,6 @@ async fn daemon_mining_test() {
     let args = Args {
         simnet: true,
         unsafe_rpc: true,
-        enable_unsynced_mining: true,
         disable_upnp: true, // UPnP registration might take some time and is not needed for this test
         ..Default::default()
     };
@@ -134,7 +133,6 @@ async fn daemon_utxos_propagation_test() {
     let args = Args {
         simnet: true,
         unsafe_rpc: true,
-        enable_unsynced_mining: true,
         disable_upnp: true, // UPnP registration might take some time and is not needed for this test
         utxoindex: true,
         ..Default::default()

--- a/testing/integration/src/mempool_benchmarks.rs
+++ b/testing/integration/src/mempool_benchmarks.rs
@@ -84,7 +84,6 @@ async fn bench_bbt_latency() {
     let args = Args {
         simnet: true,
         disable_upnp: true, // UPnP registration might take some time and is not needed for this test
-        enable_unsynced_mining: true,
         num_prealloc_utxos: Some(TX_LEVEL_WIDTH as u64 * CONTRACT_FACTOR),
         prealloc_address: Some(prealloc_address.to_string()),
         prealloc_amount: 500 * SOMPI_PER_KASPA,

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -45,7 +45,6 @@ async fn sanity_test() {
     let args = Args {
         simnet: true,
         disable_upnp: true, // UPnP registration might take some time and is not needed for this test
-        enable_unsynced_mining: true,
         block_template_cache_lifetime: Some(0),
         utxoindex: true,
         unsafe_rpc: true,

--- a/xenom/src/args.rs
+++ b/xenom/src/args.rs
@@ -61,7 +61,6 @@ pub struct Args {
     #[serde(rename = "rpcmaxclients")]
     pub rpc_max_clients: usize,
     pub max_tracked_addresses: usize,
-    pub enable_unsynced_mining: bool,
     pub enable_mainnet_mining: bool,
     pub testnet: bool,
     #[serde(rename = "netsuffix")]
@@ -107,7 +106,6 @@ impl Default for Args {
             inbound_limit: 128,
             rpc_max_clients: 128,
             max_tracked_addresses: 0,
-            enable_unsynced_mining: false,
             enable_mainnet_mining: true,
             testnet: false,
             testnet_suffix: 10,
@@ -149,7 +147,6 @@ impl Args {
         config.utxoindex = self.utxoindex;
         config.disable_upnp = self.disable_upnp;
         config.unsafe_rpc = self.unsafe_rpc;
-        config.enable_unsynced_mining = self.enable_unsynced_mining;
         config.enable_mainnet_mining = self.enable_mainnet_mining;
         config.is_archival = self.archival;
         // TODO: change to `config.enable_sanity_checks = self.sanity` when we reach stable versions
@@ -302,7 +299,6 @@ pub fn cli() -> Command {
                 .help("Max number of RPC clients for standard connections (default: 128)."),
         )
         .arg(arg!(--"reset-db" "Reset database before starting node. It's needed when switching between subnetworks."))
-        .arg(arg!(--"enable-unsynced-mining" "Allow the node to accept blocks from RPC while not synced (this flag is mainly used for testing)"))
         .arg(
             Arg::new("enable-mainnet-mining")
                 .long("enable-mainnet-mining")
@@ -428,7 +424,6 @@ impl Args {
             rpc_max_clients: arg_match_unwrap_or::<usize>(&m, "rpcmaxclients", defaults.rpc_max_clients),
             max_tracked_addresses: arg_match_unwrap_or::<usize>(&m, "max-tracked-addresses", defaults.max_tracked_addresses),
             reset_db: arg_match_unwrap_or::<bool>(&m, "reset-db", defaults.reset_db),
-            enable_unsynced_mining: arg_match_unwrap_or::<bool>(&m, "enable-unsynced-mining", defaults.enable_unsynced_mining),
             enable_mainnet_mining: arg_match_unwrap_or::<bool>(&m, "enable-mainnet-mining", defaults.enable_mainnet_mining),
             utxoindex: arg_match_unwrap_or::<bool>(&m, "utxoindex", defaults.utxoindex),
             testnet: arg_match_unwrap_or::<bool>(&m, "testnet", defaults.testnet),


### PR DESCRIPTION
…chain

The chain can be idle (no miners) for longer than the DAA window without the node being 'out of sync'. is_nearly_synced() returning false just means the last block is old, not that IBD is needed.

New logic: node is ready to mine when
  is_nearly_synced()  OR  !is_ibd_running()
The second condition covers chain revival: no peer has a longer chain so IBD never fires, yet the last-block timestamp is stale.

Removes enable_unsynced_mining from Config, Args, CLI and all tests.