### PR TITLE
ci: fix main.yml release packaging, replace deprecated macos-13 runner

### DIFF
--- a/.github/workflows/genome-miner-release.yml
+++ b/.github/workflows/genome-miner-release.yml
@@ -21,12 +21,12 @@ jobs:
             artifact: genome-miner-linux-x86_64
             binary: genome-miner
 
-          - os: macos-13          # last GitHub x86_64 macOS runner
+          - os: macos-latest      # arm64 runner, cross-compile to Intel x86_64
             target: x86_64-apple-darwin
             artifact: genome-miner-macos-x86_64
             binary: genome-miner
 
-          - os: macos-latest      # macos-14 — Apple Silicon (M1/M2/M3/M4)
+          - os: macos-latest      # Apple Silicon (M1/M2/M3/M4)
             target: aarch64-apple-darwin
             artifact: genome-miner-macos-aarch64
             binary: genome-miner

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,198 +1,172 @@
-name: Build and Upload Xenomorph Project Assets
+name: Build and Release Xenomorph
 
 on:
   push:
     tags:
-      - 'v*.*.*'  # Triggers on version tags like v1.0.0
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.15.3)'
+        required: true
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: xenom-linux-x86_64
+            archive_ext: tar.gz
+
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: xenom-macos-aarch64
+            archive_ext: tar.gz
+
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            artifact: xenom-macos-x86_64
+            archive_ext: tar.gz
+
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: xenom-windows-x86_64
+            archive_ext: zip
+
+    runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Install dependencies (including protobuf-compiler)
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler libvulkan-dev
+          sudo apt-get install -y protobuf-compiler libvulkan-dev vulkan-tools
 
-      - name: Verify protoc installation
-        run: protoc --version
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
-      - name: Cache cargo registry
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-
-
-      - name: Build for Linux
-        run: |
-          cargo build --release --bin xenom-wallet --bin xenom --bin genome-miner
-          mkdir -p linux
-          cp target/release/xenom-wallet linux/xenom-wallet
-          cp target/release/xenom linux/xenom
-          cp target/release/genome-miner linux/genome-miner
-
-      - name: Upload release artifacts (Linux)
-        uses: actions/upload-artifact@v3
-        with:
-          name: release-binaries-linux
-          path: |
-            target/release/xenom-wallet
-            target/release/xenom
-            target/release/genome-miner
-
-  build-macos:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Install Protobuf Compiler
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
         run: brew install protobuf
 
-      - name: Verify protoc installation
+      - name: Install Windows dependencies
+        if: runner.os == 'Windows'
+        run: choco install protoc --yes
+
+      - name: Verify protoc
         run: protoc --version
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
+          targets: ${{ matrix.target }}
 
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.target }}-registry-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.target }}-registry-
 
       - name: Cache cargo build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-
+          key: ${{ runner.os }}-${{ matrix.target }}-build-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.target }}-build-
 
-      - name: Build for macOS
+      - name: Build binaries
+        run: cargo build --release --bin xenom-wallet --bin xenom --bin genome-miner --target ${{ matrix.target }}
+
+      # ── Package (Linux / macOS) ─────────────────────────────────────────────
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
         run: |
-          cargo build --release --bin xenom-wallet --bin xenom --bin genome-miner
-          mkdir -p macos
-          cp target/release/xenom-wallet macos/xenom-wallet
-          cp target/release/xenom macos/xenom
-          cp target/release/genome-miner macos/genome-miner
-      - name: Upload release artifacts (macOS)
-        uses: actions/upload-artifact@v3
+          OUTDIR=dist/${{ matrix.artifact }}
+          mkdir -p "$OUTDIR"
+          cp target/${{ matrix.target }}/release/xenom-wallet "$OUTDIR/"
+          cp target/${{ matrix.target }}/release/xenom        "$OUTDIR/"
+          cp target/${{ matrix.target }}/release/genome-miner "$OUTDIR/"
+          cd dist
+          tar -czf ${{ matrix.artifact }}.tar.gz ${{ matrix.artifact }}/
+
+      # ── Package (Windows) ───────────────────────────────────────────────────
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $outdir = "dist\${{ matrix.artifact }}"
+          New-Item -ItemType Directory -Force -Path $outdir | Out-Null
+          Copy-Item "target\${{ matrix.target }}\release\xenom-wallet.exe" $outdir
+          Copy-Item "target\${{ matrix.target }}\release\xenom.exe"        $outdir
+          Copy-Item "target\${{ matrix.target }}\release\genome-miner.exe" $outdir
+          Compress-Archive -Path "$outdir\*" -DestinationPath "dist\${{ matrix.artifact }}.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
-          name: release-binaries-macos
-          path: |
-            target/release/xenom-wallet
-            target/release/xenom
-            target/release/genome-miner
-
-  build-windows:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Install Protobuf Compiler
-        run: choco install protoc
-
-      - name: Verify protoc installation
-        run: protoc --version
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
-      - name: Cache cargo registry
-        uses: actions/cache@v3
-        with:
-          path: C:\Users\runneradmin\.cargo\registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-
-
-      - name: Build for Windows
-        run: | 
-          cargo build --release --bin xenom-wallet --bin xenom --bin genome-miner
-          mkdir -p windows
-          cp target/release/xenom-wallet.exe windows/xenom-wallet.exe
-          cp target/release/xenom.exe windows/xenom.exe
-          cp target/release/genome-miner.exe windows/genome-miner.exe
-      - name: Upload release artifacts (Windows)
-        uses: actions/upload-artifact@v3
-        with:
-          name: release-binaries-windows
-          path: |
-            target\release\xenom-wallet.exe
-            target\release\xenom.exe
-            target\release\genome-miner.exe
+          name: ${{ matrix.artifact }}
+          path: dist/${{ matrix.artifact }}.${{ matrix.archive_ext }}
 
   release:
-    needs: [build-linux, build-macos, build-windows]
+    needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
     steps:
-      - name: Download Linux build artifacts
-        uses: actions/download-artifact@v3
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: release-binaries-linux
+          path: dist/
 
-      - name: Download macOS build artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: release-binaries-macos
+      - name: List artifacts
+        run: find dist/ -type f
 
-      - name: Download Windows build artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: release-binaries-windows
-
-      - name: List files in the workspace
-        run: ls -la
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: "Xenomorph ${{ steps.tag.outputs.tag }}"
+          body: |
+            ## Xenomorph ${{ steps.tag.outputs.tag }}
+
+            ### Binaries included
+            - `xenom` — node daemon
+            - `xenom-wallet` — CLI wallet
+            - `genome-miner` — GPU miner (Vulkan / Metal)
+
+            ### Downloads
+            | Platform | File |
+            |----------|------|
+            | Linux x86_64 | `xenom-linux-x86_64.tar.gz` |
+            | macOS Apple Silicon | `xenom-macos-aarch64.tar.gz` |
+            | macOS Intel | `xenom-macos-x86_64.tar.gz` |
+            | Windows x86_64 | `xenom-windows-x86_64.zip` |
+
+            ### Quick start
+            ```bash
+            tar -xzf xenom-linux-x86_64.tar.gz
+            ./xenom --utxoindex --rpclisten-borsh --mainnet
+            ```
           files: |
-            linux/xenom-wallet
-            linux/xenom
-            linux/genome-miner
-            macos/xenom-wallet
-            macos/xenom
-            macos/genome-miner
-            windows/xenom-wallet.exe
-            windows/xenom.exe
-            windows/genome-miner.exe
+            dist/xenom-linux-x86_64/xenom-linux-x86_64.tar.gz
+            dist/xenom-macos-aarch64/xenom-macos-aarch64.tar.gz
+            dist/xenom-macos-x86_64/xenom-macos-x86_64.tar.gz
+            dist/xenom-windows-x86_64/xenom-windows-x86_64.zip
+          draft: false
+          prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Notify success
-        run: echo "Release created successfully!"

--- a/cli/src/modules/account.rs
+++ b/cli/src/modules/account.rs
@@ -219,6 +219,26 @@ impl Account {
                     }
                 }
             }
+            "address" => {
+                let account = ctx.account().await?;
+                if argv.is_empty() {
+                    let addr = account.receive_address()?.to_string();
+                    tprintln!(ctx, "\n{addr}\n");
+                } else {
+                    match argv.remove(0).as_str() {
+                        "new" => {
+                            let account = account.as_derivation_capable()?;
+                            let ident = account.name_with_id();
+                            let new_address = account.new_receive_address().await?;
+                            tprintln!(ctx, "New address for account {}: {}", style(ident).cyan(), style(new_address).blue());
+                        }
+                        v => {
+                            tprintln!(ctx, "unknown sub-command: '{v}'");
+                            tprintln!(ctx, "usage: 'account address' or 'account address new'\r\n");
+                        }
+                    }
+                }
+            }
             "scan" | "sweep" => {
                 let len = argv.len();
                 let mut start = 0;
@@ -256,6 +276,8 @@ impl Account {
                 (KDX and kaspanet web wallet). Use 'account import' for additional help.",
                 ),
                 ("name <name>", "Name or rename the selected account (use 'remove' to remove the name"),
+                ("address", "Show the current receive address for this account"),
+                ("address new", "Generate and register a new receive address for this account"),
                 ("scan [<derivations>] or scan [<start>] [<derivations>]", "Scan extended address derivation chain (legacy accounts)"),
                 (
                     "sweep [<derivations>] or sweep [<start>] [<derivations>]",

--- a/crypto/txscript/Cargo.toml
+++ b/crypto/txscript/Cargo.toml
@@ -16,8 +16,6 @@ wasm32-sdk = []
 [dependencies]
 blake3.workspace = true
 blake2b_simd.workspace = true
-pqcrypto-dilithium.workspace = true
-pqcrypto-traits.workspace = true
 borsh.workspace = true
 cfg-if.workspace = true
 hexplay.workspace = true
@@ -41,6 +39,10 @@ smallvec.workspace = true
 thiserror.workspace = true
 wasm-bindgen.workspace = true
 workflow-wasm.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pqcrypto-dilithium.workspace = true
+pqcrypto-traits.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -23,7 +23,9 @@ use kaspa_txscript_errors::TxScriptError;
 use log::trace;
 use opcodes::codes::OpReturn;
 use opcodes::{codes, to_small_int, OpCond};
+#[cfg(not(target_arch = "wasm32"))]
 use pqcrypto_dilithium::dilithium3;
+#[cfg(not(target_arch = "wasm32"))]
 use pqcrypto_traits::sign::{DetachedSignature as _, PublicKey as _};
 use script_class::ScriptClass;
 
@@ -516,6 +518,9 @@ impl<'a, T: VerifiableTransaction> TxScriptEngine<'a, T> {
         pubkey_bytes: &[u8],
         sig: &[u8],
     ) -> Result<bool, TxScriptError> {
+        #[cfg(target_arch = "wasm32")]
+        { let _ = (hash_type, pubkey_hash, pubkey_bytes, sig); return Err(TxScriptError::InvalidState("PQ sig verify not supported in wasm32".into())); }
+        #[cfg(not(target_arch = "wasm32"))]
         match self.script_source {
             ScriptSource::TxInput { tx, id, .. } => {
                 let computed_hash = blake2b_simd::Params::new().hash_length(32).hash(pubkey_bytes);

--- a/crypto/txscript/src/standard.rs
+++ b/crypto/txscript/src/standard.rs
@@ -6,7 +6,9 @@ use crate::{
 use kaspa_addresses::{Address, Prefix, Version};
 use kaspa_consensus_core::tx::{ScriptPublicKey, ScriptVec};
 use kaspa_txscript_errors::TxScriptError;
+#[cfg(not(target_arch = "wasm32"))]
 use pqcrypto_dilithium::dilithium3;
+#[cfg(not(target_arch = "wasm32"))]
 use pqcrypto_traits::sign::{PublicKey as _, SecretKey as _};
 use smallvec::SmallVec;
 use std::iter::once;
@@ -125,6 +127,7 @@ pub fn build_pq_sigscript(sig_with_hashtype: &[u8], pk_bytes: &[u8]) -> Vec<u8> 
 /// Generates a fresh ML-DSA-65 (Dilithium3) key pair.
 /// Returns `(secret_key_bytes, public_key_bytes)`.
 /// Use `pq_address_from_pubkey` to obtain the corresponding `PubKeyPQ` address.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn pq_keypair() -> (Vec<u8>, Vec<u8>) {
     let (pk, sk) = dilithium3::keypair();
     (sk.as_bytes().to_vec(), pk.as_bytes().to_vec())

--- a/wasm/.cargo/config.toml
+++ b/wasm/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "link-arg=--allow-multiple-definition"]


### PR DESCRIPTION
- main.yml: full rewrite — matrix build, proper tar.gz/zip packaging, correct artifact paths in release job, tag_name, v4 actions, PowerShell Windows packaging, workflow_dispatch support
- genome-miner-release.yml: replace deprecated macos-13 with macos-latest
  + cross-compile to x86_64-apple-darwin
- cli/account: add 'account address' / 'account address new' subcommands
- crypto/txscript: gate pqcrypto behind cfg(not(target_arch="wasm32")) so the WASM SDK builds cleanly
- wasm/.cargo/config.toml: allow-multiple-definition linker flag for wasm32