### PR TITLE
fix(gpu-miner): fix 0 H/s display on multi-GPU by using block_in_plac…

### DIFF
--- a/genome-miner/src/gpu.rs
+++ b/genome-miner/src/gpu.rs
@@ -472,7 +472,7 @@ async fn dispatch_genome(worker: &mut GpuWorker, params_data: &[u8; 112], batch_
     let slice = worker.g_readback_buf.slice(..);
     let (tx, rx) = tokio::sync::oneshot::channel();
     slice.map_async(wgpu::MapMode::Read, move |r| { let _ = tx.send(r); });
-    dev.poll(wgpu::Maintain::Wait);
+    tokio::task::block_in_place(|| dev.poll(wgpu::Maintain::Wait));
     rx.await.ok()?.ok()?;
 
     let data     = slice.get_mapped_range();
@@ -507,7 +507,7 @@ async fn dispatch_kheavy(worker: &mut GpuWorker, params_data: &[u8; 88], batch_s
     let slice = worker.kh_readback_buf.slice(..);
     let (tx, rx) = tokio::sync::oneshot::channel();
     slice.map_async(wgpu::MapMode::Read, move |r| { let _ = tx.send(r); });
-    dev.poll(wgpu::Maintain::Wait);
+    tokio::task::block_in_place(|| dev.poll(wgpu::Maintain::Wait));
     rx.await.ok()?.ok()?;
 
     let data     = slice.get_mapped_range();
@@ -817,8 +817,9 @@ pub async fn cmd_gpu(m: &ArgMatches, dash: std::sync::Arc<std::sync::Mutex<DashS
             }
         }
 
-        if report_timer.elapsed() >= Duration::from_secs(5) {
-            let elapsed = report_timer.elapsed().as_secs_f64();
+        let report_elapsed = report_timer.elapsed();
+        if report_elapsed >= Duration::from_secs(5) {
+            let elapsed = report_elapsed.as_secs_f64();
             let per_gpu: Vec<f64> = hash_counters.iter()
                 .map(|c| c.swap(0, Ordering::Relaxed) as f64 / elapsed / 1_000_000.0)
                 .collect();


### PR DESCRIPTION
…e for wgpu poll

dev.poll(Maintain::Wait) is a synchronous blocking call. When called directly inside tokio::spawn async tasks (one per GPU), it blocks a tokio worker thread for the full GPU batch duration. With 10 GPUs all blocking threads simultaneously, the hashrate-reporting main loop task gets starved and the 5-second timer never fires, leaving all GPU hashrates permanently at 0 H/s (even though blocks are accepted).

Fix: wrap both dispatch_genome and dispatch_kheavy poll calls with tokio::task::block_in_place(), which signals tokio to move other pending tasks (main loop, solution handler) to available threads before blocking, eliminating the starvation.

Also fix minor double-elapsed call: capture report_timer.elapsed() once into report_elapsed before the condition check so the divisor used for MH/s calculation is exactly the same instant as the check.