### PR TITLE
move to stable rust tool chain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.1"
+channel = "stable"


### PR DESCRIPTION
Revert from latest to stable for rust tool chain.